### PR TITLE
Disable disk metrics

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -20,7 +20,8 @@ if [ "$1" = "cadvisor" ]; then
     "--http_auth_file=$auth_file" \
     "--http_auth_realm=cadvisor" \
     "--housekeeping_interval=${CADVISOR_HOUSEKEEPING_INTERVAL:="30s"}" \
-    "--global_housekeeping_interval=${CADVISOR_GLOBAL_HOUSEKEEPING_INTERVAL:="2m"}"
+    "--global_housekeeping_interval=${CADVISOR_GLOBAL_HOUSEKEEPING_INTERVAL:="2m"}" \
+    "--disable_metrics=${CADVISOR_DISABLED_METRICS:="disk,tcp"}"
 fi
 
 exec "$@"


### PR DESCRIPTION
Disk metrics are pretty expensive for the Docker container handler,
since they amount to running `du` on the container's root directory,
which is somewhat costly in terms of CPU, especially when the host has
many containers. It can also be (very) costly in terms of disk when the
volume underlying the `/var/lib/docker` directory is slow(-ish), which
is our case since it's an EBS volume.

More importantly, those metrics are very useless:

- They can't be used to predict when `/var/lib/docker` might run out of
  space, since they only account for one container's usage (that's why
  they use `du`), whereas the underlying volume is used by multiple
  containers.
- They're not at all relevant to customers. Actual relevant disk usage
  is on DB data volumes, which is not captured by Cadvisor currently
  (and *we* wouldn't need to use `du` for those, sicne each DB has its
  own underlying volume).

Long story short, those metrics are costly and useless, so we might as
well get rid of them.

---

Note: TCP metrics are disabled by default, so this hasn't changed with
this patch.